### PR TITLE
Removed unnecessary fields from DTO and API call.

### DIFF
--- a/app/src/main/java/io/mcnulty/avwx/data/remote/AvWxApi.kt
+++ b/app/src/main/java/io/mcnulty/avwx/data/remote/AvWxApi.kt
@@ -4,11 +4,23 @@ import io.mcnulty.avwx.data.remote.dto.metar.MetarDto
 import retrofit2.http.GET
 import retrofit2.http.Headers
 import retrofit2.http.Path
+import retrofit2.http.Query
+
+val removeQuery = listOf(
+        "spoken",
+        "other",
+        "sanitized",
+        "remarks_info",
+        "dt",
+        "accumulation",
+    ).joinToString("%2C")
 
 interface AvWxApi {
-    @Headers("Authorization: ")
+
+    @Headers("Authorization: DUMMY_TOKEN")
     @GET("api/metar/{fieldCode}")
     suspend fun getMetar(
-        @Path("fieldCode") fieldCode: String
+        @Path("fieldCode") fieldCode: String,
+        @Query("remove") remove: String = removeQuery
     ): MetarDto
 }

--- a/app/src/main/java/io/mcnulty/avwx/data/remote/dto/metar/AltimeterDto.kt
+++ b/app/src/main/java/io/mcnulty/avwx/data/remote/dto/metar/AltimeterDto.kt
@@ -10,11 +10,9 @@ package io.mcnulty.avwx.data.remote.dto.metar
  *
  *
  * @property repr The raw METAR string
- * @property spoken The METAR string with all abbreviations expanded
  * @property value The altimeter value
  */
 data class AltimeterDto(
     val repr: String,
-    val spoken: String,
     val value: Number
 )

--- a/app/src/main/java/io/mcnulty/avwx/data/remote/dto/metar/MetarDto.kt
+++ b/app/src/main/java/io/mcnulty/avwx/data/remote/dto/metar/MetarDto.kt
@@ -13,7 +13,6 @@ data class MetarDto(
     val dewpointDto: DewpointDto,
     @SerializedName("flight_rules")
     val flightRules: String,
-    val other: List<Any>,
     @SerializedName("pressure_altitude")
     val pressureAltitude: Int,
     val raw: String,
@@ -22,7 +21,6 @@ data class MetarDto(
     val remarks: String,
     @SerializedName("runway_visibility")
     val runwayVisibility: List<RunwayVisibilityDto>,
-    val sanitized: String,
     val station: String,
     @SerializedName("temperature")
     val temperatureDto: TemperatureDto,

--- a/app/src/main/java/io/mcnulty/avwx/data/remote/dto/metar/MetarDtoComponent.kt
+++ b/app/src/main/java/io/mcnulty/avwx/data/remote/dto/metar/MetarDtoComponent.kt
@@ -1,7 +1,0 @@
-package io.mcnulty.avwx.data.remote.dto.metar
-
-data class MetarDtoComponent(
-    val repr: String,
-    val spoken: String,
-    val value: Number
-)

--- a/app/src/main/java/io/mcnulty/avwx/data/remote/dto/metar/RunwayVisibilityDto.kt
+++ b/app/src/main/java/io/mcnulty/avwx/data/remote/dto/metar/RunwayVisibilityDto.kt
@@ -12,7 +12,6 @@ data class RunwayVisibilityDto(
 ) {
     data class RunwayVisibility(
         val repr: String,
-        val spoken: String,
         val value: Any? // API returns an Int or empty json object
     )
 }

--- a/app/src/test/java/io/mcnulty/avwx/data/repository/MetarRepositoryImplTest.kt
+++ b/app/src/test/java/io/mcnulty/avwx/data/repository/MetarRepositoryImplTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.google.gson.Gson
 import io.mcnulty.avwx.data.remote.AvWxApi
 import io.mcnulty.avwx.data.remote.dto.metar.MetarDto
+import io.mcnulty.avwx.data.remote.removeQuery
 import io.mcnulty.avwx.domain.repository.metar.MetarRepository
 import io.mcnulty.avwx.domain.use_case.parse.MetarParser
 import kotlinx.coroutines.runBlocking
@@ -112,6 +113,12 @@ class MetarRepositoryImplTest {
         }
 
         assertThat(actualResponse.errorMessage).isEqualTo("connection error")
+    }
+
+    @Test
+    fun `check valid remove query`() {
+        assertThat(removeQuery)
+            .isEqualTo("spoken%2Cother%2Csanitized%2Cremarks_info%2Cdt%2Caccumulation")
     }
 
     @After

--- a/app/src/test/java/io/mcnulty/avwx/data/repository/MetarRepositoryImplTest.kt
+++ b/app/src/test/java/io/mcnulty/avwx/data/repository/MetarRepositoryImplTest.kt
@@ -121,6 +121,7 @@ class MetarRepositoryImplTest {
             .isEqualTo("spoken%2Cother%2Csanitized%2Cremarks_info%2Cdt%2Caccumulation")
     }
 
+    @Test
     fun `test invalid search parameter`() {
         val expectedResponse = MockResponse()
             .setResponseCode(HttpURLConnection.HTTP_BAD_REQUEST)

--- a/app/src/test/java/io/mcnulty/avwx/domain/use_case/parse/AltimeterParserTest.kt
+++ b/app/src/test/java/io/mcnulty/avwx/domain/use_case/parse/AltimeterParserTest.kt
@@ -9,7 +9,7 @@ class AltimeterParserTest {
     @Test
     fun `parse should return AtmosphericPressure Altimeter when using PressureUnits INCHES_OF_MERCURY`() {
         // Arrange
-        val altimeterDto = AltimeterDto("A2966", "two nine point six six", 29.66)
+        val altimeterDto = AltimeterDto("A2966", 29.66)
         val units = PressureUnits.INCHES_OF_MERCURY
 
         // Act
@@ -22,7 +22,7 @@ class AltimeterParserTest {
     @Test
     fun `parse should return AtmosphericPressure Qnh when using PressureUnits HECTOPASCALS`() {
         // Arrange
-        val altimeterDto = AltimeterDto("Q1000", "one zero zero zero", 1000)
+        val altimeterDto = AltimeterDto("Q1000", 1000)
         val units = PressureUnits.HECTOPASCALS
 
         // Act

--- a/app/src/test/java/io/mcnulty/avwx/domain/use_case/parse/RVRParserTest.kt
+++ b/app/src/test/java/io/mcnulty/avwx/domain/use_case/parse/RVRParserTest.kt
@@ -12,7 +12,6 @@ class RVRParserTest {
         repr: String
     ) = RunwayVisibilityDto.RunwayVisibility(
         repr = repr,
-        spoken = "",
         value = 0
     )
 


### PR DESCRIPTION
Unable to remove 'meta' field from API call. Current removed fields are:

- spoken
- other
- sanitized
- remarks_info
- dt
- accumulation

Merge and close of PR closes issue.